### PR TITLE
CustomApiException 누락된 필드 추가

### DIFF
--- a/src/main/java/com/sparta/twitNation/ex/CustomApiException.java
+++ b/src/main/java/com/sparta/twitNation/ex/CustomApiException.java
@@ -1,8 +1,16 @@
 package com.sparta.twitNation.ex;
 
+import lombok.Getter;
+
+@Getter
 public class CustomApiException extends RuntimeException{
-    public CustomApiException(String message){
+
+    private final int status;
+    private final String msg;
+    public CustomApiException(String message, int  status){
         super(message);
+        this.msg = message;
+        this.status = status;
     }
 
 }


### PR DESCRIPTION
#7 
CustomApiException 클래스의 예외 메시지와 상태 코드를 처리하는 필드가 누락되어 있어 다음 두 필드를 클래스에 추가하였습니다.
추가된 필드는 다음과 같습니다:

private final int status: 예외 발생 시 반환할 HTTP 상태 코드
private final String msg: 예외에 대한 사용자 정의 메시지