### PR TITLE
게시글 생성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ out/
 
 ### VS Code ###
 .vscode/
+
+java/com/sparta/twitNation/config/DevInit.java

--- a/src/main/java/com/sparta/twitNation/controller/PostController.java
+++ b/src/main/java/com/sparta/twitNation/controller/PostController.java
@@ -1,0 +1,2 @@
+package com.sparta.twitNation.controller;public class PostController {
+}

--- a/src/main/java/com/sparta/twitNation/controller/PostController.java
+++ b/src/main/java/com/sparta/twitNation/controller/PostController.java
@@ -1,2 +1,29 @@
-package com.sparta.twitNation.controller;public class PostController {
+package com.sparta.twitNation.controller;
+
+
+import com.sparta.twitNation.config.auth.LoginUser;
+import com.sparta.twitNation.dto.post.req.PostCreateReqDto;
+import com.sparta.twitNation.dto.post.resp.PostCreateRespDto;
+import com.sparta.twitNation.service.PostService;
+import com.sparta.twitNation.util.api.ApiResult;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/posts")
+public class PostController {
+
+    private final PostService postService;
+
+    @PostMapping
+    public ResponseEntity<ApiResult<PostCreateRespDto>> createPost(@RequestBody @Valid PostCreateReqDto postCreateReqDto, @AuthenticationPrincipal LoginUser loginUser){
+        return new ResponseEntity<>(ApiResult.success(postService.createPost(postCreateReqDto, loginUser)), HttpStatus.CREATED);
+    }
+
 }

--- a/src/main/java/com/sparta/twitNation/domain/post/Post.java
+++ b/src/main/java/com/sparta/twitNation/domain/post/Post.java
@@ -5,6 +5,7 @@ import com.sparta.twitNation.domain.base.BaseEntity;
 import com.sparta.twitNation.domain.user.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -25,4 +26,11 @@ public class Post extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
+
+    @Builder
+    public Post(Long id, String content, User user) {
+        this.id = id;
+        this.content = content;
+        this.user = user;
+    }
 }

--- a/src/main/java/com/sparta/twitNation/domain/post/PostRepository.java
+++ b/src/main/java/com/sparta/twitNation/domain/post/PostRepository.java
@@ -1,0 +1,8 @@
+package com.sparta.twitNation.domain.post;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PostRepository extends JpaRepository<Post, Long> {
+}

--- a/src/main/java/com/sparta/twitNation/domain/user/User.java
+++ b/src/main/java/com/sparta/twitNation/domain/user/User.java
@@ -30,9 +30,13 @@ public class User extends BaseEntity {
     private String password;
 
     @Builder
-    public User(Long id, String username, String password) {
+    public User(Long id, String username, String email, String nickname, String bio, String profileImg, String password) {
         this.id = id;
         this.username = username;
+        this.email = email;
+        this.nickname = nickname;
+        this.bio = bio;
+        this.profileImg = profileImg;
         this.password = password;
     }
 }

--- a/src/main/java/com/sparta/twitNation/dto/post/req/PostCreateReqDto.java
+++ b/src/main/java/com/sparta/twitNation/dto/post/req/PostCreateReqDto.java
@@ -1,4 +1,22 @@
 package com.sparta.twitNation.dto.post.req;
 
-public class PostCreateReqDto {
+import com.sparta.twitNation.domain.post.Post;
+import com.sparta.twitNation.domain.user.User;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
+
+public record PostCreateReqDto(
+        @NotBlank(message = "내용을 작성해야 합니다")
+        @Length(min = 1, max = 1024, message = "게시글은 최소 1자 최대 1024자로 작성해야 합니다")
+        String content
+) {
+    public Post toEntity(User user) {
+        return Post.builder()
+                .content(this.content())
+                .user(user)
+                .build();
+    }
 }

--- a/src/main/java/com/sparta/twitNation/dto/post/resp/PostCreateRespDto.java
+++ b/src/main/java/com/sparta/twitNation/dto/post/resp/PostCreateRespDto.java
@@ -1,4 +1,10 @@
 package com.sparta.twitNation.dto.post.resp;
 
-public class PostCreateRespDto {
+import com.sparta.twitNation.domain.post.Post;
+
+public record PostCreateRespDto(Long postId) {
+
+    public PostCreateRespDto (Post post){
+        this(post.getId());
+    }
 }

--- a/src/main/java/com/sparta/twitNation/dto/post/resp/PostCreateRespDto.java
+++ b/src/main/java/com/sparta/twitNation/dto/post/resp/PostCreateRespDto.java
@@ -4,7 +4,7 @@ import com.sparta.twitNation.domain.post.Post;
 
 public record PostCreateRespDto(Long postId) {
 
-    public PostCreateRespDto (Post post){
+    public PostCreateRespDto(Post post) {
         this(post.getId());
     }
 }

--- a/src/main/java/com/sparta/twitNation/ex/CustomApiException.java
+++ b/src/main/java/com/sparta/twitNation/ex/CustomApiException.java
@@ -5,12 +5,10 @@ import lombok.Getter;
 @Getter
 public class CustomApiException extends RuntimeException{
 
-    private final int status;
-    private final String msg;
-    public CustomApiException(String message, int  status){
-        super(message);
-        this.msg = message;
-        this.status = status;
+    private final ErrorCode errorCode;
+    public CustomApiException(ErrorCode errorCode){
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
     }
 
 }

--- a/src/main/java/com/sparta/twitNation/ex/ErrorCode.java
+++ b/src/main/java/com/sparta/twitNation/ex/ErrorCode.java
@@ -1,0 +1,20 @@
+package com.sparta.twitNation.ex;
+import lombok.Getter;
+
+@Getter
+public enum ErrorCode {
+
+    USER_NOT_FOUND(404, "존재하지 않는 유저입니다"),
+    INTERNAL_SERVER_ERROR(500, "서버 내부 오류");
+
+
+    private final int status;
+    private final String message;
+
+    ErrorCode(int status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+
+}

--- a/src/main/java/com/sparta/twitNation/handler/CustomExceptionHandler.java
+++ b/src/main/java/com/sparta/twitNation/handler/CustomExceptionHandler.java
@@ -1,7 +1,29 @@
 package com.sparta.twitNation.handler;
 
+import com.sparta.twitNation.ex.CustomApiException;
+import com.sparta.twitNation.util.api.ApiResult;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @RestControllerAdvice
 public class CustomExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResult<Map<String, String>>> validationException(MethodArgumentNotValidException e){
+        Map<String, String> errorMap = new HashMap<>();
+        e.getBindingResult().getFieldErrors().forEach(error -> errorMap.put(error.getField(), error.getDefaultMessage()));
+        return new ResponseEntity<>(ApiResult.error(HttpStatus.BAD_REQUEST.value(), "유효성 검사 실패", errorMap), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(CustomApiException.class)
+    public ResponseEntity<ApiResult<String>> apiException(CustomApiException e){
+        return new ResponseEntity<>(ApiResult.error(e.getStatus(), e.getMsg()), HttpStatusCode.valueOf(e.getStatus()));
+    }
 }

--- a/src/main/java/com/sparta/twitNation/handler/CustomExceptionHandler.java
+++ b/src/main/java/com/sparta/twitNation/handler/CustomExceptionHandler.java
@@ -24,6 +24,6 @@ public class CustomExceptionHandler {
 
     @ExceptionHandler(CustomApiException.class)
     public ResponseEntity<ApiResult<String>> apiException(CustomApiException e){
-        return new ResponseEntity<>(ApiResult.error(e.getStatus(), e.getMsg()), HttpStatusCode.valueOf(e.getStatus()));
+        return new ResponseEntity<>(ApiResult.error(e.getErrorCode().getStatus(), e.getErrorCode().getMessage()), HttpStatusCode.valueOf(e.getErrorCode().getStatus()));
     }
 }

--- a/src/main/java/com/sparta/twitNation/service/PostService.java
+++ b/src/main/java/com/sparta/twitNation/service/PostService.java
@@ -28,7 +28,7 @@ public class PostService {
     public PostCreateRespDto createPost(PostCreateReqDto postCreateReqDto, LoginUser loginUser){
         Long userId = loginUser.getUser().getId();
         if (userId == null) {
-            log.error("인증 실패: userId null");
+            log.error("인증 실패: userId is null");
             throw new CustomApiException("인증 정보가 유효하지 않습니다", HttpStatus.UNAUTHORIZED.value());
         }
         User user = userRepository.findById(userId).orElseThrow(

--- a/src/main/java/com/sparta/twitNation/service/PostService.java
+++ b/src/main/java/com/sparta/twitNation/service/PostService.java
@@ -8,6 +8,7 @@ import com.sparta.twitNation.domain.user.UserRepository;
 import com.sparta.twitNation.dto.post.req.PostCreateReqDto;
 import com.sparta.twitNation.dto.post.resp.PostCreateRespDto;
 import com.sparta.twitNation.ex.CustomApiException;
+import com.sparta.twitNation.ex.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,12 +28,8 @@ public class PostService {
     @Transactional
     public PostCreateRespDto createPost(PostCreateReqDto postCreateReqDto, LoginUser loginUser){
         Long userId = loginUser.getUser().getId();
-        if (userId == null) {
-            log.error("인증 실패: userId is null");
-            throw new CustomApiException("인증 정보가 유효하지 않습니다", HttpStatus.UNAUTHORIZED.value());
-        }
         User user = userRepository.findById(userId).orElseThrow(
-                () -> new CustomApiException("존재하지 않는 유저입니다", HttpStatus.NOT_FOUND.value())
+                () -> new CustomApiException(ErrorCode.USER_NOT_FOUND)
         );
         Post post = postRepository.save(postCreateReqDto.toEntity(user));
         return new PostCreateRespDto(post);

--- a/src/main/java/com/sparta/twitNation/service/PostService.java
+++ b/src/main/java/com/sparta/twitNation/service/PostService.java
@@ -1,5 +1,6 @@
 package com.sparta.twitNation.service;
 
+import com.sparta.twitNation.config.auth.LoginUser;
 import com.sparta.twitNation.domain.post.Post;
 import com.sparta.twitNation.domain.post.PostRepository;
 import com.sparta.twitNation.domain.user.User;
@@ -8,6 +9,9 @@ import com.sparta.twitNation.dto.post.req.PostCreateReqDto;
 import com.sparta.twitNation.dto.post.resp.PostCreateRespDto;
 import com.sparta.twitNation.ex.CustomApiException;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,11 +22,17 @@ public class PostService {
 
     private final PostRepository postRepository;
     private final UserRepository userRepository;
+    private final Logger log = LoggerFactory.getLogger(this.getClass());
 
     @Transactional
-    public PostCreateRespDto createPost(PostCreateReqDto postCreateReqDto, Long userId){
+    public PostCreateRespDto createPost(PostCreateReqDto postCreateReqDto, LoginUser loginUser){
+        Long userId = loginUser.getUser().getId();
+        if (userId == null) {
+            log.error("인증 실패: userId null");
+            throw new CustomApiException("인증 정보가 유효하지 않습니다", HttpStatus.UNAUTHORIZED.value());
+        }
         User user = userRepository.findById(userId).orElseThrow(
-                () -> new CustomApiException("존재하지 않는 유저입니다")
+                () -> new CustomApiException("존재하지 않는 유저입니다", HttpStatus.NOT_FOUND.value())
         );
         Post post = postRepository.save(postCreateReqDto.toEntity(user));
         return new PostCreateRespDto(post);

--- a/src/main/java/com/sparta/twitNation/service/PostService.java
+++ b/src/main/java/com/sparta/twitNation/service/PostService.java
@@ -1,0 +1,31 @@
+package com.sparta.twitNation.service;
+
+import com.sparta.twitNation.domain.post.Post;
+import com.sparta.twitNation.domain.post.PostRepository;
+import com.sparta.twitNation.domain.user.User;
+import com.sparta.twitNation.domain.user.UserRepository;
+import com.sparta.twitNation.dto.post.req.PostCreateReqDto;
+import com.sparta.twitNation.dto.post.resp.PostCreateRespDto;
+import com.sparta.twitNation.ex.CustomApiException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class PostService {
+
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public PostCreateRespDto createPost(PostCreateReqDto postCreateReqDto, Long userId){
+        User user = userRepository.findById(userId).orElseThrow(
+                () -> new CustomApiException("존재하지 않는 유저입니다")
+        );
+        Post post = postRepository.save(postCreateReqDto.toEntity(user));
+        return new PostCreateRespDto(post);
+    }
+
+}

--- a/src/test/java/com/sparta/twitNation/config/jwt/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/sparta/twitNation/config/jwt/JwtAuthenticationFilterTest.java
@@ -50,7 +50,7 @@ class JwtAuthenticationFilterTest {
     @Test
     void success_authentication_test() throws Exception {
         //given
-        LoginReqDto loginReqDto = LoginReqDto.builder().username("username").password("password").build();
+        LoginReqDto loginReqDto = LoginReqDto.builder().username("userA").password("password").build();
         String requestBody = om.writeValueAsString(loginReqDto);
         System.out.println("requestBody = " + requestBody);
 
@@ -69,7 +69,7 @@ class JwtAuthenticationFilterTest {
         resultActions.andExpect(status().isOk());
         assertNotNull(jwtToken);
         assertTrue(jwtToken.startsWith(JwtVo.TOKEN_PREFIX));
-        resultActions.andExpect(jsonPath("$.data.username").value("username"));
+        resultActions.andExpect(jsonPath("$.data.username").value("userA"));
     }
 
     @Test

--- a/src/test/java/com/sparta/twitNation/config/jwt/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/sparta/twitNation/config/jwt/JwtAuthenticationFilterTest.java
@@ -43,7 +43,8 @@ class JwtAuthenticationFilterTest {
     @BeforeEach
     public void setUp() throws  Exception{
         String password = "password";
-        userRepository.save(new User(1L, "username", passwordEncoder.encode(password)));
+        User user = User.builder().id(1L).username("userA").nickname("userAAAAAAAA").email("userA@email.com").password(passwordEncoder.encode(password)).build();
+        userRepository.save(user);
     }
 
     @Test

--- a/src/test/java/com/sparta/twitNation/config/jwt/JwtProcessTest.java
+++ b/src/test/java/com/sparta/twitNation/config/jwt/JwtProcessTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.MockitoAnnotations;
 import org.springframework.http.HttpStatus;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.util.Date;
 

--- a/src/test/java/com/sparta/twitNation/controller/PostControllerTest.java
+++ b/src/test/java/com/sparta/twitNation/controller/PostControllerTest.java
@@ -1,0 +1,137 @@
+package com.sparta.twitNation.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sparta.twitNation.config.auth.LoginUser;
+import com.sparta.twitNation.config.jwt.JwtProcess;
+import com.sparta.twitNation.config.jwt.JwtVo;
+import com.sparta.twitNation.domain.post.Post;
+import com.sparta.twitNation.domain.user.User;
+import com.sparta.twitNation.domain.user.UserRepository;
+import com.sparta.twitNation.dto.post.req.PostCreateReqDto;
+import com.sparta.twitNation.dto.post.resp.PostCreateRespDto;
+import com.sparta.twitNation.service.PostService;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.test.context.support.TestExecutionEvent;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.context.support.WithUserDetails;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.ResultMatcher;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import static org.awaitility.Awaitility.given;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.request;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+class PostControllerTest {
+
+    @Autowired
+    private PostService postService;
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private ObjectMapper om;
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private BCryptPasswordEncoder passwordEncoder;
+
+    @Autowired
+    private EntityManager em;
+
+    @Autowired
+    private JwtProcess jwtProcess;
+
+    private String token;
+
+    @BeforeEach
+    void setUp(){
+        String password = "password";
+        User user = User.builder().id(1L).username("userA").nickname("userAAAAAAAA").email("userA@email.com").password(passwordEncoder.encode(password)).build();
+        userRepository.save(user);
+        em.clear();
+
+        LoginUser loginUser = new LoginUser(user);
+        token = jwtProcess.create(loginUser);
+    }
+
+    @WithUserDetails(value = "userA",setupBefore = TestExecutionEvent.TEST_EXECUTION )
+    @Test
+    void success_createPost_test() throws Exception {
+
+        //given
+        PostCreateReqDto postCreateReqDto = new PostCreateReqDto("test content");
+        String requestBody = om.writeValueAsString(postCreateReqDto);
+
+        //when
+        ResultActions resultActions = mvc.perform(post("/api/posts")
+                .header(JwtVo.HEADER, token)
+                .content(requestBody)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated());
+
+        String responseBody = resultActions.andReturn().getResponse().getContentAsString();
+        System.out.println("responseBody = " + responseBody);
+    }
+
+    @WithUserDetails(value = "userA",setupBefore = TestExecutionEvent.TEST_EXECUTION )
+    @Test
+    void fail_createPost_invalid_length_test() throws Exception {
+
+        //given
+        PostCreateReqDto postCreateReqDto = new PostCreateReqDto("");
+        String requestBody = om.writeValueAsString(postCreateReqDto);
+
+        //when
+        ResultActions resultActions = mvc.perform(post("/api/posts")
+                        .header(JwtVo.HEADER, token)
+                        .content(requestBody)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.apiError.msg").value("유효성 검사 실패"))
+                .andExpect(jsonPath("$.apiError.status").value(400));
+
+        String responseBody = resultActions.andReturn().getResponse().getContentAsString();
+        System.out.println("responseBody = " + responseBody);
+    }
+
+    @WithUserDetails(value = "userA",setupBefore = TestExecutionEvent.TEST_EXECUTION )
+    @Test
+    void fail_createPost_invalid_notBlank_test() throws Exception {
+
+        //given
+        PostCreateReqDto postCreateReqDto = new PostCreateReqDto(" ");
+        String requestBody = om.writeValueAsString(postCreateReqDto);
+
+        //when
+        ResultActions resultActions = mvc.perform(post("/api/posts")
+                        .header(JwtVo.HEADER, token)
+                        .content(requestBody)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.apiError.msg").value("유효성 검사 실패"))
+                .andExpect(jsonPath("$.apiError.status").value(400));
+
+        String responseBody = resultActions.andReturn().getResponse().getContentAsString();
+        System.out.println("responseBody = " + responseBody);
+    }
+}

--- a/src/test/java/com/sparta/twitNation/service/PostServiceTest.java
+++ b/src/test/java/com/sparta/twitNation/service/PostServiceTest.java
@@ -1,0 +1,57 @@
+package com.sparta.twitNation.service;
+
+import com.sparta.twitNation.config.auth.LoginUser;
+import com.sparta.twitNation.domain.post.Post;
+import com.sparta.twitNation.domain.post.PostRepository;
+import com.sparta.twitNation.domain.user.User;
+import com.sparta.twitNation.domain.user.UserRepository;
+import com.sparta.twitNation.dto.post.req.PostCreateReqDto;
+import com.sparta.twitNation.dto.post.resp.PostCreateRespDto;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
+class PostServiceTest {
+
+    @InjectMocks
+    private PostService postService;
+
+    @Mock
+    private PostRepository postRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Test
+    void success_createPost_test(){
+        //given
+        Long userId = 1L;
+        String content = "test content";
+
+        User user = User.builder().id(userId).build();
+        Post post = Post.builder().user(user).content(content).build();
+        LoginUser loginUser = new LoginUser(user);
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(postRepository.save(any())).thenReturn(post);
+
+        //when
+        PostCreateRespDto result = postService.createPost(new PostCreateReqDto(content), loginUser);
+
+        //then
+        assertNotNull(result);
+        verify(postRepository).save(any(Post.class));
+    }
+}

--- a/src/test/java/com/sparta/twitNation/service/PostServiceTest.java
+++ b/src/test/java/com/sparta/twitNation/service/PostServiceTest.java
@@ -7,6 +7,7 @@ import com.sparta.twitNation.domain.user.User;
 import com.sparta.twitNation.domain.user.UserRepository;
 import com.sparta.twitNation.dto.post.req.PostCreateReqDto;
 import com.sparta.twitNation.dto.post.resp.PostCreateRespDto;
+import com.sparta.twitNation.ex.CustomApiException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -53,5 +54,28 @@ class PostServiceTest {
         //then
         assertNotNull(result);
         verify(postRepository).save(any(Post.class));
+    }
+
+    @Test
+    void fail_createPost_userIdIsNull_test(){
+        LoginUser loginUser = new LoginUser(User.builder().build());
+
+        assertThrows(CustomApiException.class, () -> {
+            postService.createPost(new PostCreateReqDto("test content"), loginUser);
+        });
+    }
+
+    @Test
+    void fail_createPost_userNotFound_test(){
+        //given
+        Long userId = 1L;
+        User user = User.builder().id(userId).build();
+        LoginUser loginUser = new LoginUser(user);
+
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+        assertThrows(CustomApiException.class, () ->{
+            postService.createPost(new PostCreateReqDto("test content"), loginUser);
+        });
     }
 }


### PR DESCRIPTION
## 1. 게시글 생성
### 전체 시나리오

1) loginUser 객체에서 꺼낸 User의 userId가 null이 아닌지 검증
2) null이 아니라면 userRepository에서 해당 유저 조회 (null일시 에러 throw)
3) post 생성 후 저장
4) post의 id값 반환

### 게시글 생성 요청 DTO
- valid
  - length:  content 길이최소 1자 최대 1024자
  - notBlank

### 응답
게시글 생성 응답 DTO와 created 상태 반환


## 2.  전역 핸들러
다음 두 핸들러를 추가했습니다:
- validExcpetion: dto 유효성 검사 실패 오류 핸들러 추가
- apiException: api 오류 핸들러 추가