### PR TITLE
[Feat] 마이페이지 게시물 정보 조회 기능 구현

### DIFF
--- a/src/main/java/com/sparta/twitNation/controller/PostController.java
+++ b/src/main/java/com/sparta/twitNation/controller/PostController.java
@@ -1,0 +1,29 @@
+package com.sparta.twitNation.controller;
+
+import com.sparta.twitNation.dto.post.resp.UserPostsRespDto;
+import com.sparta.twitNation.service.PostService;
+import com.sparta.twitNation.util.api.ApiResult;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class PostController {
+
+    private final PostService postService;
+
+    @GetMapping("/api/users/profile/{userId}/posts")
+    public ResponseEntity<ApiResult<UserPostsRespDto>> readPostByUser(
+            @PathVariable final Long userId,
+            @RequestParam(defaultValue = "0", value = "page") int page,
+            @RequestParam(defaultValue = "10", value = "limit") int limit
+    ) {
+        final UserPostsRespDto response = postService.readPostsBy(userId, page, limit);
+        return new ResponseEntity<>(ApiResult.success(response), HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/sparta/twitNation/controller/PostController.java
+++ b/src/main/java/com/sparta/twitNation/controller/PostController.java
@@ -17,7 +17,7 @@ public class PostController {
 
     private final PostService postService;
 
-    @GetMapping("/api/users/profile/{userId}/posts")
+    @GetMapping("/api/posts/{userId}")
     public ResponseEntity<ApiResult<UserPostsRespDto>> readPostByUser(
             @PathVariable final Long userId,
             @RequestParam(defaultValue = "0", value = "page") int page,

--- a/src/main/java/com/sparta/twitNation/domain/comment/CommentRepository.java
+++ b/src/main/java/com/sparta/twitNation/domain/comment/CommentRepository.java
@@ -1,0 +1,12 @@
+package com.sparta.twitNation.domain.comment;
+
+import com.sparta.twitNation.domain.post.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    @Query("SELECT COUNT(l) FROM Like l WHERE l.post = :post")
+    int countByPost(@Param("post") final Post post);
+}

--- a/src/main/java/com/sparta/twitNation/domain/like/LikeRepository.java
+++ b/src/main/java/com/sparta/twitNation/domain/like/LikeRepository.java
@@ -1,0 +1,12 @@
+package com.sparta.twitNation.domain.like;
+
+import com.sparta.twitNation.domain.post.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface LikeRepository extends JpaRepository<Like, Long> {
+
+    @Query("SELECT COUNT(l) FROM Like l WHERE l.post = :post")
+    int countByPost(@Param("post") final Post post);
+}

--- a/src/main/java/com/sparta/twitNation/domain/post/PostRepository.java
+++ b/src/main/java/com/sparta/twitNation/domain/post/PostRepository.java
@@ -1,0 +1,13 @@
+package com.sparta.twitNation.domain.post;
+
+import com.sparta.twitNation.domain.user.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PostRepository extends JpaRepository<Post, Long> {
+
+    Page<Post> findByUser(final User user, final Pageable pageable);
+}

--- a/src/main/java/com/sparta/twitNation/domain/retweet/RetweetRepository.java
+++ b/src/main/java/com/sparta/twitNation/domain/retweet/RetweetRepository.java
@@ -1,0 +1,12 @@
+package com.sparta.twitNation.domain.retweet;
+
+import com.sparta.twitNation.domain.post.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface RetweetRepository extends JpaRepository<Retweet, Long> {
+
+    @Query("SELECT COUNT(l) FROM Like l WHERE l.post = :post")
+    int countByPost(@Param("post") final Post post);
+}

--- a/src/main/java/com/sparta/twitNation/dto/post/resp/PostReadPageRespDto.java
+++ b/src/main/java/com/sparta/twitNation/dto/post/resp/PostReadPageRespDto.java
@@ -1,0 +1,34 @@
+package com.sparta.twitNation.dto.post.resp;
+
+import com.sparta.twitNation.domain.post.Post;
+import com.sparta.twitNation.domain.user.User;
+import java.time.LocalDateTime;
+
+public record PostReadPageRespDto(
+        String userNickname,
+        String userProfileImg,
+        String content,
+        LocalDateTime modifiedAt,
+        int likeCount,
+        int commentCount,
+        int retweetCount
+) {
+
+    public static PostReadPageRespDto from(
+            final User user,
+            final Post post,
+            final int likeCount,
+            final int commentCount,
+            final int retweetCount
+    ) {
+        return new PostReadPageRespDto(
+                user.getNickname(),
+                user.getProfileImg(),
+                post.getContent(),
+                post.getLastModifiedAt(),
+                likeCount,
+                commentCount,
+                retweetCount
+        );
+    }
+}

--- a/src/main/java/com/sparta/twitNation/dto/post/resp/UserPostsRespDto.java
+++ b/src/main/java/com/sparta/twitNation/dto/post/resp/UserPostsRespDto.java
@@ -1,0 +1,26 @@
+package com.sparta.twitNation.dto.post.resp;
+
+import java.util.List;
+import org.springframework.data.domain.Page;
+
+public record UserPostsRespDto(
+        int elementsCount,
+        int currentPage,
+        int nextPage,
+        int pageCount,
+        boolean nextPageBool,
+        int pageSize,
+        List<PostReadPageRespDto> posts
+) {
+    public static UserPostsRespDto from(final Page<PostReadPageRespDto> posts) {
+        return new UserPostsRespDto(
+                (int) posts.getTotalElements(),
+                posts.getNumber(),
+                posts.hasNext() ? posts.getNumber() + 1 : -1,
+                posts.getTotalPages(),
+                posts.hasNext(),
+                posts.getSize(),
+                posts.getContent()
+        );
+    }
+}

--- a/src/main/java/com/sparta/twitNation/service/PostService.java
+++ b/src/main/java/com/sparta/twitNation/service/PostService.java
@@ -13,6 +13,7 @@ import com.sparta.twitNation.ex.CustomApiException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,7 +32,8 @@ public class PostService {
     public UserPostsRespDto readPostsBy(final Long userId, final int page, final int limit) {
         final User user = userRepository.findById(userId).orElseThrow(
                 () -> new CustomApiException("존재하지 않는 유저입니다", HttpStatus.NOT_FOUND.value()));
-        final Page<Post> posts = postRepository.findByUser(user, PageRequest.of(page, limit));
+        final Page<Post> posts = postRepository.findByUser(user,
+                PageRequest.of(page, limit, Sort.by(Sort.Direction.DESC, "lastModifiedAt")));
 
         final Page<PostReadPageRespDto> response = posts.map(
                 post -> {

--- a/src/main/java/com/sparta/twitNation/service/PostService.java
+++ b/src/main/java/com/sparta/twitNation/service/PostService.java
@@ -1,0 +1,46 @@
+package com.sparta.twitNation.service;
+
+import com.sparta.twitNation.domain.comment.CommentRepository;
+import com.sparta.twitNation.domain.like.LikeRepository;
+import com.sparta.twitNation.domain.post.Post;
+import com.sparta.twitNation.domain.post.PostRepository;
+import com.sparta.twitNation.domain.retweet.RetweetRepository;
+import com.sparta.twitNation.domain.user.User;
+import com.sparta.twitNation.domain.user.UserRepository;
+import com.sparta.twitNation.dto.post.resp.PostReadPageRespDto;
+import com.sparta.twitNation.dto.post.resp.UserPostsRespDto;
+import com.sparta.twitNation.ex.CustomApiException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PostService {
+
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+    private final LikeRepository likeRepository;
+    private final CommentRepository commentRepository;
+    private final RetweetRepository retweetRepository;
+
+    @Transactional(readOnly = true)
+    public UserPostsRespDto readPostsBy(final Long userId, final int page, final int limit) {
+        final User user = userRepository.findById(userId).orElseThrow(
+                () -> new CustomApiException("존재하지 않는 유저입니다", HttpStatus.NOT_FOUND.value()));
+        final Page<Post> posts = postRepository.findByUser(user, PageRequest.of(page, limit));
+
+        final Page<PostReadPageRespDto> response = posts.map(
+                post -> {
+                    final int likeCount = likeRepository.countByPost(post);
+                    final int commentCount = commentRepository.countByPost(post);
+                    final int retweetCount = retweetRepository.countByPost(post);
+                    return PostReadPageRespDto.from(user, post, likeCount, commentCount, retweetCount);
+                });
+
+        return UserPostsRespDto.from(response);
+    }
+}


### PR DESCRIPTION
이슈 번호 : #15 

### 마이페이지 게시물 정보 조회 기능

1. PostReadPageDataRespDto, UserPostsRespDto record 정의
2. 유저 정보 찾기
3. 유저가 쓴 게시물 찾기
4. 게시물에 대한 좋아요 수, 리트윗 수, 댓글 수 찾기
5. 페이지 정보 포함 응답 