### PR TITLE
댓글 기능 추가

### DIFF
--- a/src/main/java/com/sparta/twitNation/controller/CommentController.java
+++ b/src/main/java/com/sparta/twitNation/controller/CommentController.java
@@ -4,6 +4,7 @@ import com.sparta.twitNation.config.auth.LoginUser;
 import com.sparta.twitNation.dto.comment.req.CommentCreateReqDto;
 import com.sparta.twitNation.dto.comment.req.CommentModifyReqDto;
 import com.sparta.twitNation.dto.comment.resp.CommentCreateRespDto;
+import com.sparta.twitNation.dto.comment.resp.CommentDeleteRespDto;
 import com.sparta.twitNation.dto.comment.resp.CommentModifyRespDto;
 import com.sparta.twitNation.service.CommentService;
 import com.sparta.twitNation.util.api.ApiResult;
@@ -36,6 +37,12 @@ public class CommentController {
                                                                          @RequestBody @Valid CommentModifyReqDto commentModifyReqDto,
                                                                          @AuthenticationPrincipal LoginUser loginUser) {
         return new ResponseEntity<>(ApiResult.success(commentService.updateComment(postId, commentId, commentModifyReqDto, loginUser)), HttpStatus.OK);
+    }
+    @DeleteMapping("/posts/{postId}/comments/{commentId}")
+    public ResponseEntity<ApiResult<CommentDeleteRespDto>> deleteComment(@PathVariable(name = "postId") Long postId,
+                                                                         @PathVariable(name="commentId") Long commentId,
+                                                                         @AuthenticationPrincipal LoginUser loginUser) {
+        return new ResponseEntity<>(ApiResult.success(commentService.deleteComment(postId,commentId,loginUser)), HttpStatus.OK);
     }
 
 }

--- a/src/main/java/com/sparta/twitNation/controller/CommentController.java
+++ b/src/main/java/com/sparta/twitNation/controller/CommentController.java
@@ -1,0 +1,30 @@
+package com.sparta.twitNation.controller;
+
+import com.sparta.twitNation.config.auth.LoginUser;
+import com.sparta.twitNation.dto.comment.req.CommentCreateReqDto;
+import com.sparta.twitNation.dto.comment.resp.CommentCreateRespDto;
+import com.sparta.twitNation.service.CommentService;
+import com.sparta.twitNation.util.api.ApiResult;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api")
+@Validated
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @PostMapping("/posts/{postId}/comments")
+    public ResponseEntity<ApiResult<CommentCreateRespDto>> createComment(@PathVariable(name = "postId") Long postId,
+                                                                         @RequestBody @Valid CommentCreateReqDto commentCreateReqDto,
+                                                                         @AuthenticationPrincipal LoginUser loginUser) {
+        return new ResponseEntity<>(ApiResult.success(commentService.createComment(commentCreateReqDto,loginUser,postId)), HttpStatus.CREATED);
+    }
+}

--- a/src/main/java/com/sparta/twitNation/controller/CommentController.java
+++ b/src/main/java/com/sparta/twitNation/controller/CommentController.java
@@ -28,7 +28,7 @@ public class CommentController {
     public ResponseEntity<ApiResult<CommentCreateRespDto>> createComment(@PathVariable(name = "postId") Long postId,
                                                                          @RequestBody @Valid CommentCreateReqDto commentCreateReqDto,
                                                                          @AuthenticationPrincipal LoginUser loginUser) {
-        return new ResponseEntity<>(ApiResult.success(commentService.createComment(commentCreateReqDto,loginUser,postId)), HttpStatus.CREATED);
+        return new ResponseEntity<>(ApiResult.success(commentService.createComment(commentCreateReqDto, loginUser, postId)), HttpStatus.CREATED);
     }
 
     @PutMapping("/posts/{postId}/comments/{commentId}")
@@ -38,11 +38,12 @@ public class CommentController {
                                                                          @AuthenticationPrincipal LoginUser loginUser) {
         return new ResponseEntity<>(ApiResult.success(commentService.updateComment(postId, commentId, commentModifyReqDto, loginUser)), HttpStatus.OK);
     }
+
     @DeleteMapping("/posts/{postId}/comments/{commentId}")
     public ResponseEntity<ApiResult<CommentDeleteRespDto>> deleteComment(@PathVariable(name = "postId") Long postId,
-                                                                         @PathVariable(name="commentId") Long commentId,
+                                                                         @PathVariable(name = "commentId") Long commentId,
                                                                          @AuthenticationPrincipal LoginUser loginUser) {
-        return new ResponseEntity<>(ApiResult.success(commentService.deleteComment(postId,commentId,loginUser)), HttpStatus.OK);
+        return new ResponseEntity<>(ApiResult.success(commentService.deleteComment(postId, commentId, loginUser)), HttpStatus.OK);
     }
 
 }

--- a/src/main/java/com/sparta/twitNation/controller/CommentController.java
+++ b/src/main/java/com/sparta/twitNation/controller/CommentController.java
@@ -2,7 +2,9 @@ package com.sparta.twitNation.controller;
 
 import com.sparta.twitNation.config.auth.LoginUser;
 import com.sparta.twitNation.dto.comment.req.CommentCreateReqDto;
+import com.sparta.twitNation.dto.comment.req.CommentModifyReqDto;
 import com.sparta.twitNation.dto.comment.resp.CommentCreateRespDto;
+import com.sparta.twitNation.dto.comment.resp.CommentModifyRespDto;
 import com.sparta.twitNation.service.CommentService;
 import com.sparta.twitNation.util.api.ApiResult;
 import jakarta.validation.Valid;
@@ -27,4 +29,13 @@ public class CommentController {
                                                                          @AuthenticationPrincipal LoginUser loginUser) {
         return new ResponseEntity<>(ApiResult.success(commentService.createComment(commentCreateReqDto,loginUser,postId)), HttpStatus.CREATED);
     }
+
+    @PutMapping("/posts/{postId}/comments/{commentId}")
+    public ResponseEntity<ApiResult<CommentModifyRespDto>> updateComment(@PathVariable(name = "postId") Long postId,
+                                                                         @PathVariable(name = "commentId") Long commentId,
+                                                                         @RequestBody @Valid CommentModifyReqDto commentModifyReqDto,
+                                                                         @AuthenticationPrincipal LoginUser loginUser) {
+        return new ResponseEntity<>(ApiResult.success(commentService.updateComment(postId, commentId, commentModifyReqDto, loginUser)), HttpStatus.OK);
+    }
+
 }

--- a/src/main/java/com/sparta/twitNation/domain/comment/Comment.java
+++ b/src/main/java/com/sparta/twitNation/domain/comment/Comment.java
@@ -40,7 +40,12 @@ public class Comment extends BaseEntity {
     }
 
     public void modify(String content) {
-        if (content != null)
+        if (content != null) {
             this.content = content;
+        }
+    }
+
+    public boolean isWrittenBy(Long userId) {
+        return this.user.getId().equals(userId);
     }
 }

--- a/src/main/java/com/sparta/twitNation/domain/comment/Comment.java
+++ b/src/main/java/com/sparta/twitNation/domain/comment/Comment.java
@@ -3,6 +3,7 @@ package com.sparta.twitNation.domain.comment;
 import com.sparta.twitNation.domain.base.BaseEntity;
 import com.sparta.twitNation.domain.post.Post;
 import com.sparta.twitNation.domain.user.User;
+import com.sparta.twitNation.dto.comment.req.CommentModifyReqDto;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -36,5 +37,10 @@ public class Comment extends BaseEntity {
         this.user = user;
         this.post = post;
         this.id = id;
+    }
+
+    public void modify(CommentModifyReqDto commentModifyReqDto) {
+        if (commentModifyReqDto.content() != null)
+            this.content = commentModifyReqDto.content();
     }
 }

--- a/src/main/java/com/sparta/twitNation/domain/comment/Comment.java
+++ b/src/main/java/com/sparta/twitNation/domain/comment/Comment.java
@@ -5,6 +5,7 @@ import com.sparta.twitNation.domain.post.Post;
 import com.sparta.twitNation.domain.user.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -28,4 +29,12 @@ public class Comment extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
+
+    @Builder
+    public Comment(String content, User user, Post post, Long id) {
+        this.content = content;
+        this.user = user;
+        this.post = post;
+        this.id = id;
+    }
 }

--- a/src/main/java/com/sparta/twitNation/domain/comment/Comment.java
+++ b/src/main/java/com/sparta/twitNation/domain/comment/Comment.java
@@ -39,8 +39,8 @@ public class Comment extends BaseEntity {
         this.id = id;
     }
 
-    public void modify(CommentModifyReqDto commentModifyReqDto) {
-        if (commentModifyReqDto.content() != null)
-            this.content = commentModifyReqDto.content();
+    public void modify(String content) {
+        if (content != null)
+            this.content = content;
     }
 }

--- a/src/main/java/com/sparta/twitNation/domain/comment/CommentRepository.java
+++ b/src/main/java/com/sparta/twitNation/domain/comment/CommentRepository.java
@@ -1,0 +1,8 @@
+package com.sparta.twitNation.domain.comment;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+@Repository
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+}

--- a/src/main/java/com/sparta/twitNation/domain/comment/CommentRepository.java
+++ b/src/main/java/com/sparta/twitNation/domain/comment/CommentRepository.java
@@ -2,6 +2,7 @@ package com.sparta.twitNation.domain.comment;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 

--- a/src/main/java/com/sparta/twitNation/dto/comment/req/CommentCreateReqDto.java
+++ b/src/main/java/com/sparta/twitNation/dto/comment/req/CommentCreateReqDto.java
@@ -1,4 +1,15 @@
 package com.sparta.twitNation.dto.comment.req;
 
-public class CommentCreateReqDto {
+import com.sparta.twitNation.domain.comment.Comment;
+import com.sparta.twitNation.domain.post.Post;
+import com.sparta.twitNation.domain.user.User;
+
+public record CommentCreateReqDto(String content){
+    public Comment toEntity(Post post, User user) {
+        return Comment.builder()
+                .content(this.content)
+                .post(post)
+                .user(user)
+                .build();
+    }
 }

--- a/src/main/java/com/sparta/twitNation/dto/comment/req/CommentCreateReqDto.java
+++ b/src/main/java/com/sparta/twitNation/dto/comment/req/CommentCreateReqDto.java
@@ -3,8 +3,12 @@ package com.sparta.twitNation.dto.comment.req;
 import com.sparta.twitNation.domain.comment.Comment;
 import com.sparta.twitNation.domain.post.Post;
 import com.sparta.twitNation.domain.user.User;
+import jakarta.validation.constraints.NotBlank;
+import org.hibernate.validator.constraints.Length;
 
-public record CommentCreateReqDto(String content){
+public record CommentCreateReqDto( @NotBlank(message = "내용을 작성해야 합니다")
+                                   @Length(min = 1, max = 512, message = "게시글은 최소 1자 최대 512자로 작성해야 합니다")
+                                   String content){
     public Comment toEntity(Post post, User user) {
         return Comment.builder()
                 .content(this.content)

--- a/src/main/java/com/sparta/twitNation/dto/comment/req/CommentCreateReqDto.java
+++ b/src/main/java/com/sparta/twitNation/dto/comment/req/CommentCreateReqDto.java
@@ -6,9 +6,9 @@ import com.sparta.twitNation.domain.user.User;
 import jakarta.validation.constraints.NotBlank;
 import org.hibernate.validator.constraints.Length;
 
-public record CommentCreateReqDto( @NotBlank(message = "내용을 작성해야 합니다")
-                                   @Length(min = 1, max = 512, message = "게시글은 최소 1자 최대 512자로 작성해야 합니다")
-                                   String content){
+public record CommentCreateReqDto(@NotBlank(message = "내용을 작성해야 합니다")
+                                  @Length(min = 1, max = 512, message = "게시글은 최소 1자 최대 512자로 작성해야 합니다")
+                                  String content) {
     public Comment toEntity(Post post, User user) {
         return Comment.builder()
                 .content(this.content)

--- a/src/main/java/com/sparta/twitNation/dto/comment/req/CommentModifyReqDto.java
+++ b/src/main/java/com/sparta/twitNation/dto/comment/req/CommentModifyReqDto.java
@@ -1,0 +1,19 @@
+package com.sparta.twitNation.dto.comment.req;
+
+import com.sparta.twitNation.domain.comment.Comment;
+import com.sparta.twitNation.domain.post.Post;
+import com.sparta.twitNation.domain.user.User;
+import jakarta.validation.constraints.NotBlank;
+import org.hibernate.validator.constraints.Length;
+
+public record CommentModifyReqDto(@NotBlank(message = "내용을 작성해야 합니다")
+                                  @Length(min = 1, max = 512, message = "게시글은 최소 1자 최대 512자로 작성해야 합니다")
+                                  String content) {
+    public Comment toEntity(Post post, User user) {
+        return Comment.builder()
+                .content(this.content)
+                .post(post)
+                .user(user)
+                .build();
+    }
+}

--- a/src/main/java/com/sparta/twitNation/dto/comment/resp/CommentCreateRespDto.java
+++ b/src/main/java/com/sparta/twitNation/dto/comment/resp/CommentCreateRespDto.java
@@ -1,4 +1,3 @@
 package com.sparta.twitNation.dto.comment.resp;
 
-public class CommentCreateRespDto {
-}
+public record CommentCreateRespDto(Long postId, Long CommentId) { }

--- a/src/main/java/com/sparta/twitNation/dto/comment/resp/CommentCreateRespDto.java
+++ b/src/main/java/com/sparta/twitNation/dto/comment/resp/CommentCreateRespDto.java
@@ -1,3 +1,3 @@
 package com.sparta.twitNation.dto.comment.resp;
 
-public record CommentCreateRespDto(Long postId, Long CommentId) { }
+public record CommentCreateRespDto(Long postId, Long commentId) { }

--- a/src/main/java/com/sparta/twitNation/dto/comment/resp/CommentDeleteRespDto.java
+++ b/src/main/java/com/sparta/twitNation/dto/comment/resp/CommentDeleteRespDto.java
@@ -1,0 +1,3 @@
+package com.sparta.twitNation.dto.comment.resp;
+
+public record CommentDeleteRespDto(Long commentId, boolean isDeleted){ }

--- a/src/main/java/com/sparta/twitNation/dto/comment/resp/CommentDeleteRespDto.java
+++ b/src/main/java/com/sparta/twitNation/dto/comment/resp/CommentDeleteRespDto.java
@@ -1,3 +1,4 @@
 package com.sparta.twitNation.dto.comment.resp;
 
-public record CommentDeleteRespDto(Long commentId, boolean isDeleted){ }
+public record CommentDeleteRespDto(Long commentId, boolean isDeleted) {
+}

--- a/src/main/java/com/sparta/twitNation/dto/comment/resp/CommentModifyRespDto.java
+++ b/src/main/java/com/sparta/twitNation/dto/comment/resp/CommentModifyRespDto.java
@@ -1,0 +1,6 @@
+package com.sparta.twitNation.dto.comment.resp;
+
+import java.time.LocalDateTime;
+
+public record CommentModifyRespDto(Long postId, Long commentId, LocalDateTime lastModifiedAt) {
+}

--- a/src/main/java/com/sparta/twitNation/ex/ErrorCode.java
+++ b/src/main/java/com/sparta/twitNation/ex/ErrorCode.java
@@ -7,7 +7,9 @@ public enum ErrorCode {
     USER_NOT_FOUND(404, "존재하지 않는 유저입니다"),
     INTERNAL_SERVER_ERROR(500, "서버 내부 오류"),
     POST_FORBIDDEN(403, "해당 게시글을 수정할 권한이 없습니다"),
-    POST_NOT_FOUND(404, "존재하지 않는 게시글입니다");
+    POST_NOT_FOUND(404, "존재하지 않는 게시글입니다"),
+    COMMENT_FORBIDEN(403,"해당 댓글을 수정할 권한이 없습니다."),
+    COMMENT_NOT_FOUND(404, "존재하지 않는 댓글입니다.");
 
 
     private final int status;

--- a/src/main/java/com/sparta/twitNation/service/CommentService.java
+++ b/src/main/java/com/sparta/twitNation/service/CommentService.java
@@ -11,6 +11,7 @@ import com.sparta.twitNation.dto.comment.resp.CommentCreateRespDto;
 import com.sparta.twitNation.dto.comment.resp.CommentDeleteRespDto;
 import com.sparta.twitNation.dto.comment.resp.CommentModifyRespDto;
 import com.sparta.twitNation.ex.CustomApiException;
+import com.sparta.twitNation.ex.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -31,7 +32,7 @@ public class CommentService {
         Long userId = loginUser.getUser().getId();
 
         Post post = postRepository.findById(postId).orElseThrow(
-                () -> new CustomApiException("존재하지 않는 트윗입니다.", HttpStatus.NOT_FOUND.value())
+                () -> new CustomApiException(ErrorCode.POST_NOT_FOUND)
         );
 
         Comment comment = commentRepository.save(commentReqDto.toEntity(post, loginUser.getUser()));
@@ -45,16 +46,16 @@ public class CommentService {
         Long userId = loginUser.getUser().getId();
 
         Post post = postRepository.findById(postId).orElseThrow(
-                () -> new CustomApiException("존재하지 않는 트윗입니다.", HttpStatus.NOT_FOUND.value())
+                () -> new CustomApiException(ErrorCode.POST_NOT_FOUND)
         );
 
 
         Comment comment = commentRepository.findById(commentId).orElseThrow(
-                () -> new CustomApiException("댓글을 찾을 수 없습니다", HttpStatus.NOT_FOUND.value())
+                () -> new CustomApiException(ErrorCode.COMMENT_NOT_FOUND)
         );
 
         if (!comment.isWrittenBy(userId)) {
-            throw new CustomApiException("해당 댓글에 접근할 권한이 없습니다", HttpStatus.UNAUTHORIZED.value());
+            throw new CustomApiException(ErrorCode.COMMENT_FORBIDEN);
         }
 
         comment.modify(commentModifyReqDto.content());
@@ -69,15 +70,15 @@ public class CommentService {
         Long userId = loginUser.getUser().getId();
 
         Post post = postRepository.findById(postId).orElseThrow(
-                () -> new CustomApiException("존재하지 않는 트윗입니다.", HttpStatus.NOT_FOUND.value())
+                () -> new CustomApiException(ErrorCode.POST_NOT_FOUND)
         );
 
         Comment comment = commentRepository.findById(commentId).orElseThrow(
-                () -> new CustomApiException("댓글을 찾을 수 없습니다", HttpStatus.NOT_FOUND.value())
+                () -> new CustomApiException(ErrorCode.COMMENT_NOT_FOUND)
         );
 
         if (!comment.isWrittenBy(userId)) {
-            throw new CustomApiException("해당 댓글에 접근할 권한이 없습니다", HttpStatus.UNAUTHORIZED.value());
+            throw new CustomApiException(ErrorCode.COMMENT_FORBIDEN);
         }
 
         commentRepository.deleteById(comment.getId());

--- a/src/main/java/com/sparta/twitNation/service/CommentService.java
+++ b/src/main/java/com/sparta/twitNation/service/CommentService.java
@@ -1,0 +1,44 @@
+package com.sparta.twitNation.service;
+
+import com.sparta.twitNation.config.auth.LoginUser;
+import com.sparta.twitNation.domain.comment.Comment;
+import com.sparta.twitNation.domain.comment.CommentRepository;
+import com.sparta.twitNation.domain.post.Post;
+import com.sparta.twitNation.domain.post.PostRepository;
+import com.sparta.twitNation.dto.comment.req.CommentCreateReqDto;
+import com.sparta.twitNation.dto.comment.resp.CommentCreateRespDto;
+import com.sparta.twitNation.ex.CustomApiException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CommentService {
+    private final PostRepository postRepository;
+    private final CommentRepository commentRepository;
+
+    @Transactional
+    public CommentCreateRespDto createComment(CommentCreateReqDto commentReqDto, LoginUser loginUser, Long postId) {
+        Long userId = loginUser.getUser().getId();
+
+        if (userId == null) {
+            log.error("인증 실패: userId is null");
+            throw new CustomApiException("인증 정보가 유효하지 않습니다", HttpStatus.UNAUTHORIZED.value());
+        }
+
+        Post post = postRepository.findById(postId).orElseThrow(
+                ()->new CustomApiException("존재하지 않는 트윗입니다.", HttpStatus.NOT_FOUND.value())
+        );
+
+        Comment comment = commentRepository.save(commentReqDto.toEntity(post,loginUser.getUser()));
+
+        return new CommentCreateRespDto(comment.getPost().getId() ,comment.getId());
+    }
+
+
+}

--- a/src/main/java/com/sparta/twitNation/service/CommentService.java
+++ b/src/main/java/com/sparta/twitNation/service/CommentService.java
@@ -21,7 +21,9 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class CommentService {
+
     private final PostRepository postRepository;
+
     private final CommentRepository commentRepository;
 
     @Transactional
@@ -33,12 +35,12 @@ public class CommentService {
         }
 
         Post post = postRepository.findById(postId).orElseThrow(
-                ()->new CustomApiException("존재하지 않는 트윗입니다.", HttpStatus.NOT_FOUND.value())
+                () -> new CustomApiException("존재하지 않는 트윗입니다.", HttpStatus.NOT_FOUND.value())
         );
 
-        Comment comment = commentRepository.save(commentReqDto.toEntity(post,loginUser.getUser()));
+        Comment comment = commentRepository.save(commentReqDto.toEntity(post, loginUser.getUser()));
 
-        return new CommentCreateRespDto(comment.getPost().getId() ,comment.getId());
+        return new CommentCreateRespDto(comment.getPost().getId(), comment.getId());
     }
 
     @Transactional
@@ -51,23 +53,23 @@ public class CommentService {
         }
 
         Post post = postRepository.findById(postId).orElseThrow(
-                ()->new CustomApiException("존재하지 않는 트윗입니다.", HttpStatus.NOT_FOUND.value())
+                () -> new CustomApiException("존재하지 않는 트윗입니다.", HttpStatus.NOT_FOUND.value())
         );
 
 
         Comment comment = commentRepository.findById(commentId).orElseThrow(
-                ()->new CustomApiException("댓글을 찾을 수 없습니다",HttpStatus.NOT_FOUND.value())
+                () -> new CustomApiException("댓글을 찾을 수 없습니다", HttpStatus.NOT_FOUND.value())
         );
 
         if (!comment.getUser().getId().equals(userId)) {
-            throw new CustomApiException("해당 댓글에 접근할 권한이 없습니다",HttpStatus.UNAUTHORIZED.value());
+            throw new CustomApiException("해당 댓글에 접근할 권한이 없습니다", HttpStatus.UNAUTHORIZED.value());
         }
 
-        comment.modify(commentModifyReqDto);
+        comment.modify(commentModifyReqDto.content());
 
         commentRepository.saveAndFlush(comment);
 
-        return new CommentModifyRespDto(comment.getPost().getId(),comment.getId(),comment.getLastModifiedAt());
+        return new CommentModifyRespDto(comment.getPost().getId(), comment.getId(), comment.getLastModifiedAt());
     }
 
     @Transactional
@@ -79,15 +81,15 @@ public class CommentService {
         }
 
         Post post = postRepository.findById(postId).orElseThrow(
-                ()->new CustomApiException("존재하지 않는 트윗입니다.", HttpStatus.NOT_FOUND.value())
+                () -> new CustomApiException("존재하지 않는 트윗입니다.", HttpStatus.NOT_FOUND.value())
         );
 
         Comment comment = commentRepository.findById(commentId).orElseThrow(
-                ()->new CustomApiException("댓글을 찾을 수 없습니다",HttpStatus.NOT_FOUND.value())
+                () -> new CustomApiException("댓글을 찾을 수 없습니다", HttpStatus.NOT_FOUND.value())
         );
 
         if (!comment.getUser().getId().equals(userId)) {
-            throw new CustomApiException("해당 댓글에 접근할 권한이 없습니다",HttpStatus.UNAUTHORIZED.value());
+            throw new CustomApiException("해당 댓글에 접근할 권한이 없습니다", HttpStatus.UNAUTHORIZED.value());
         }
 
         commentRepository.deleteById(comment.getId());

--- a/src/main/java/com/sparta/twitNation/service/CommentService.java
+++ b/src/main/java/com/sparta/twitNation/service/CommentService.java
@@ -53,13 +53,13 @@ public class CommentService {
                 () -> new CustomApiException("댓글을 찾을 수 없습니다", HttpStatus.NOT_FOUND.value())
         );
 
-        if (!comment.getUser().getId().equals(userId)) {
+        if (!comment.isWrittenBy(userId)) {
             throw new CustomApiException("해당 댓글에 접근할 권한이 없습니다", HttpStatus.UNAUTHORIZED.value());
         }
 
         comment.modify(commentModifyReqDto.content());
 
-        commentRepository.saveAndFlush(comment);
+        commentRepository.save(comment);
 
         return new CommentModifyRespDto(comment.getPost().getId(), comment.getId(), comment.getLastModifiedAt());
     }
@@ -76,12 +76,12 @@ public class CommentService {
                 () -> new CustomApiException("댓글을 찾을 수 없습니다", HttpStatus.NOT_FOUND.value())
         );
 
-        if (!comment.getUser().getId().equals(userId)) {
+        if (!comment.isWrittenBy(userId)) {
             throw new CustomApiException("해당 댓글에 접근할 권한이 없습니다", HttpStatus.UNAUTHORIZED.value());
         }
 
         commentRepository.deleteById(comment.getId());
 
-        return new CommentDeleteRespDto(comment.getId(), true);
+        return new CommentDeleteRespDto(comment.getId(), commentRepository.existsById(commentId));
     }
 }

--- a/src/main/java/com/sparta/twitNation/service/CommentService.java
+++ b/src/main/java/com/sparta/twitNation/service/CommentService.java
@@ -59,9 +59,9 @@ public class CommentService {
 
         comment.modify(commentModifyReqDto.content());
 
-        commentRepository.save(comment);
+        Comment updatedComment = commentRepository.saveAndFlush(comment);
 
-        return new CommentModifyRespDto(comment.getPost().getId(), comment.getId(), comment.getLastModifiedAt());
+        return new CommentModifyRespDto(updatedComment.getPost().getId(), updatedComment.getId(), updatedComment.getLastModifiedAt());
     }
 
     @Transactional

--- a/src/main/java/com/sparta/twitNation/service/CommentService.java
+++ b/src/main/java/com/sparta/twitNation/service/CommentService.java
@@ -30,10 +30,6 @@ public class CommentService {
     public CommentCreateRespDto createComment(CommentCreateReqDto commentReqDto, LoginUser loginUser, Long postId) {
         Long userId = loginUser.getUser().getId();
 
-        if (userId == null) {
-            throw new CustomApiException("인증 정보가 유효하지 않습니다", HttpStatus.UNAUTHORIZED.value());
-        }
-
         Post post = postRepository.findById(postId).orElseThrow(
                 () -> new CustomApiException("존재하지 않는 트윗입니다.", HttpStatus.NOT_FOUND.value())
         );
@@ -47,10 +43,6 @@ public class CommentService {
     public CommentModifyRespDto updateComment(Long postId, Long commentId, CommentModifyReqDto commentModifyReqDto, LoginUser loginUser) {
 
         Long userId = loginUser.getUser().getId();
-
-        if (userId == null) {
-            throw new CustomApiException("인증 정보가 유효하지 않습니다", HttpStatus.UNAUTHORIZED.value());
-        }
 
         Post post = postRepository.findById(postId).orElseThrow(
                 () -> new CustomApiException("존재하지 않는 트윗입니다.", HttpStatus.NOT_FOUND.value())
@@ -75,10 +67,6 @@ public class CommentService {
     @Transactional
     public CommentDeleteRespDto deleteComment(Long postId, Long commentId, LoginUser loginUser) {
         Long userId = loginUser.getUser().getId();
-
-        if (userId == null) {
-            throw new CustomApiException("인증 정보가 유효하지 않습니다", HttpStatus.UNAUTHORIZED.value());
-        }
 
         Post post = postRepository.findById(postId).orElseThrow(
                 () -> new CustomApiException("존재하지 않는 트윗입니다.", HttpStatus.NOT_FOUND.value())


### PR DESCRIPTION
## 시나리오

### 생성
1. #### 유저 존재 검증
userId로 유저가 존재하는지 확인 (존재하지 않을 경우 예외 발생)

2. #### 트윗 존재 검증
postId로 트윗이 존재하는지 확인 (존재하지 않을 경우 예외 발생)

3. #### 게시글 엔티티 변환 및 저장
DTO의 toEntity() 메서드를 사용해 Comment엔티티로 변환 -> 저장

4. #### 응답 반환
생성된 댓글의 post_id와 comment_id를 응답으로 반환

### 수정
1. #### 유저 존재 검증
userId로 유저가 존재하는지 확인 (존재하지 않을 경우 예외 발생)

2. #### 트윗 존재 검증
postId로 트윗이 존재하는지 확인 (존재하지 않을 경우 예외 발생)

3. #### 댓글 존재 검증
commentId로 댓글이 존재하는지 확인 (존재하지 않을 경우 예외 발생)

4. #### 기존 댓글 내용 가져온 뒤 수정
commentId로 댓글 정보를 가져온 뒤 수정

5. #### 응답 반환
수정된 댓글의 post_id와 comment_id 와 수정날짜 반환

### 삭제
1. #### 유저 존재 검증
userId로 유저가 존재하는지 확인 (존재하지 않을 경우 예외 발생)

2. #### 트윗 존재 검증
postId로 트윗이 존재하는지 확인 (존재하지 않을 경우 예외 발생)

3. #### 댓글 존재 검증
commentId로 댓글이 존재하는지 확인 (존재하지 않을 경우 예외 발생)

4. #### 댓글 삭제 및 응답 반환
댓글을 삭제 처리 후에 commentId,isDeleted값 반환