### PR TITLE
유저 정보 수정 리펙토링 

### DIFF
--- a/src/main/java/com/sparta/twitNation/dto/user/resp/UserEditPageRespDto.java
+++ b/src/main/java/com/sparta/twitNation/dto/user/resp/UserEditPageRespDto.java
@@ -6,11 +6,10 @@ public record UserEditPageRespDto (
         String nickname,
         String email,
         String bio,
-        String password,
         String profileImg
 ){
 
     public UserEditPageRespDto(User user){
-        this(user.getNickname(), user.getEmail(), user.getBio(), user.getPassword(), user.getProfileImg());
+        this(user.getNickname(), user.getEmail(), user.getBio(), user.getProfileImg());
     }
 }

--- a/src/main/java/com/sparta/twitNation/ex/ErrorCode.java
+++ b/src/main/java/com/sparta/twitNation/ex/ErrorCode.java
@@ -14,7 +14,8 @@ public enum ErrorCode {
     COMMENT_NOT_FOUND(404, "존재하지 않는 댓글입니다."),
     ALREADY_USER_EXIST(400, "존재하는 사용자입니다."),
     TOKEN_MISSING(401, "Authorization 헤더가 누락되었습니다"),
-    MISS_MATCHER_PASSWORD(401, "비밀번호가 일치하지 않습니다.");
+    MISS_MATCHER_PASSWORD(401, "비밀번호가 일치하지 않습니다."),
+    SAME_PASSWORD_MATCHER(400, "동일한 비밀번호로는 변경할 수 없습니다.");
 
 
     private final int status;

--- a/src/main/java/com/sparta/twitNation/service/UserService.java
+++ b/src/main/java/com/sparta/twitNation/service/UserService.java
@@ -54,6 +54,10 @@ public class UserService {
         User findUser = userRepository.findById(userId).orElseThrow(() ->
                 new CustomApiException(ErrorCode.USER_NOT_FOUND));
 
+        if (passwordEncoder.matches(dto.password(), findUser.getPassword())) {
+            throw new CustomApiException(ErrorCode.SAME_PASSWORD_MATCHER);
+        }
+
         findUser.changeInfo(reqDto);
         return new UserUpdateRespDto(findUser);
     }


### PR DESCRIPTION
1. 유저 정보 수정페이지 진입 시 패스워드 필드 삭제 
2. 유저 정보 수정시 동일한 패스워드 수정 불가 
이슈 : #57 